### PR TITLE
Fix CSS bindings warning

### DIFF
--- a/addon/components/hold.js
+++ b/addon/components/hold.js
@@ -4,7 +4,7 @@ import Config from '../configuration';
 export default Ember.Component.extend({
     current: Ember.inject.service('current-routed-modal'),
     classNames: Config.modalClassNames,
-    style: 'display: block; padding-left: 0px;',
+    style: Ember.String.htmlSafe('display: block; padding-left: 0px;'),
     tabindex: '-1',
     role: 'dialog',
     attributeBindings: ['style', 'tabindex', 'role'],


### PR DESCRIPTION
Fix a warning generated on runtime by Ember 2.12+:

> WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes

Indeed, http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes indicates that to resolve this warning, only SafeStrings should be bound to the `style` property.

@dbbk what do you think?