### PR TITLE
Fix routing deprecation for Ember 2.13

### DIFF
--- a/app/services/current-routed-modal.js
+++ b/app/services/current-routed-modal.js
@@ -26,8 +26,9 @@ export default Ember.Service.extend({
         }
     },
     close() {
-        const rout = this.get('routing.router.router');
-        const handlerInfos = this.get('routing.router.router.state.handlerInfos');
+        const routerMain = this.get('routing.router');
+        const routerLib = routerMain._routerMicrolib || routerMain.router;
+        const handlerInfos = routerLib.state.handlerInfos;
         const currentController = handlerInfos[handlerInfos.length - 1]._handler.controller;
 
         this.set('routeName', null);
@@ -35,11 +36,11 @@ export default Ember.Service.extend({
         if (currentController._isModalRoute) {
             const parentRoute = handlerInfos[handlerInfos.length - 2].name;
 
-            rout.transitionTo(parentRoute);
+            routerLib.transitionTo(parentRoute);
         } else {
             const url = this.get('routing').generateURL(this.get('routing.currentPath'));
 
-            rout.updateURL(url);
+            routerLib.updateURL(url);
         }
     }
 });


### PR DESCRIPTION
Accessing the private property `routing.routing` is deprecated, and has been replaced by `routing._routerMicrolib` ([deprecation guide](https://www.emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib)).

A [previous commit](https://github.com/dbbk/ember-routable-modal/commit/ec3ea76d87cbdaae44c279962d2baf5a24349247) attempted to tackle this deprecation. Some of the deprecated pattern was fixed, but other still remain.

This PR replaces the last accesses to `routing.routing` by `routing._routerMicrolib`.