### PR TITLE
support router flag 'resetNameSpace=true' 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+.idea

--- a/app/services/current-routed-modal.js
+++ b/app/services/current-routed-modal.js
@@ -38,7 +38,7 @@ export default Ember.Service.extend({
 
             routerLib.transitionTo(parentRoute);
         } else {
-            const url = this.get('routing').generateURL(this.get('routing.currentPath'));
+            const url = this.get('routing').generateURL(this.get('routing.currentRouteName'));
 
             routerLib.updateURL(url);
         }


### PR DESCRIPTION
Fix current-modal-route service for cases when the current route includes 'resetNameSpace=true' in router.js