### PR TITLE
Fixing issue with modals when app uses hash location type

### DIFF
--- a/app/services/current-routed-modal.js
+++ b/app/services/current-routed-modal.js
@@ -14,7 +14,7 @@ export default Ember.Service.extend({
 
         if (typeof Ember.$ !== 'undefined' && typeof window !== 'undefined') {
             Ember.$(window).on('popstate.ember-routable-modal', () => {
-                if (this.get('routeName')) {
+                if (this.get('routeName') !== this.get('routing.router.currentRouteName')) {
                     this.set('routeName', null);
                 }
             });


### PR DESCRIPTION
The `popstate` event is triggered after a transition completes when an app uses the `hash` locationType. Since the `routeName` is set at this point, it becomes unset, causing the `outlet` to be removed, so the URL is correct, but no modal is displayed.