### PR TITLE
Close method in current-routed-modal service failed on parameterized route

### DIFF
--- a/app/services/current-routed-modal.js
+++ b/app/services/current-routed-modal.js
@@ -29,8 +29,12 @@ export default Ember.Service.extend({
         const routerMain = this.get('routing.router');
         const routerLib = routerMain._routerMicrolib || routerMain.router;
         const handlerInfos = routerLib.state.handlerInfos;
-        const currentController = handlerInfos[handlerInfos.length - 1]._handler.controller;
-
+        const currentHandlerInfos = handlerInfos[handlerInfos.length - 1];
+        const currentHandler = currentHandlerInfos._handler;
+        const currentController = currentHandler.controller;
+        const currentModel = currentHandler.currentModel;
+        const hasDynamicSegments = currentHandlerInfos.params.length > 0;
+        
         this.set('routeName', null);
 
         if (currentController._isModalRoute) {
@@ -38,7 +42,13 @@ export default Ember.Service.extend({
 
             routerLib.transitionTo(parentRoute);
         } else {
-            const url = this.get('routing').generateURL(this.get('routing.currentRouteName'), currentController.get('model'));
+            let url;
+
+            if (hasDynamicSegments) {
+              url = this.get('routing').generateURL(this.get('routing.currentRouteName'), currentModel);
+            } else {
+              url = this.get('routing').generateURL(this.get('routing.currentRouteName'), []);
+            }
 
             routerLib.updateURL(url);
         }

--- a/app/services/current-routed-modal.js
+++ b/app/services/current-routed-modal.js
@@ -38,7 +38,7 @@ export default Ember.Service.extend({
 
             routerLib.transitionTo(parentRoute);
         } else {
-            const url = this.get('routing').generateURL(this.get('routing.currentRouteName'));
+            const url = this.get('routing').generateURL(this.get('routing.currentRouteName'), currentController.get('model'));
 
             routerLib.updateURL(url);
         }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,7 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    'ember-cli-babel': { includePolyfill: true }
   });
 
   /*


### PR DESCRIPTION
Adding the model of the currentController to the url generation on closing the modal via service fixed the error, which occurred on closing a route with dynamic segments.